### PR TITLE
Fix Next.js plugin detection

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -34,6 +34,14 @@ export default [
   },
   js.configs.recommended,
   {
+    plugins: {
+      "@next/next": next
+    },
+    rules: {
+      ...next.configs["core-web-vitals"].rules
+    }
+  },
+  {
     files: ["**/*.{js,jsx,ts,tsx}"],
     languageOptions: {
       ecmaVersion: "latest",
@@ -61,7 +69,7 @@ export default [
     },
     plugins: {
       import: importPlugin,
-      next,
+      "@next/next": next,
       prettier,
       react,
       "react-hooks": reactHooks,
@@ -84,12 +92,8 @@ export default [
       ...reactHooks.configs.recommended.rules,
       ...importPlugin.configs.recommended.rules,
 
-      // Next.js Core Web Vitals (remapped to flat format)
-      ...Object.fromEntries(
-        Object.entries(next.configs["core-web-vitals"].rules).map(
-          ([rule, val]) => [rule.replace("@next/next/", "next/"), val]
-        )
-      ),
+      // Next.js Core Web Vitals
+      ...next.configs["core-web-vitals"].rules,
 
       // Prettier formatting rules
       "prettier/prettier": [

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -69,7 +69,6 @@ export default [
     },
     plugins: {
       import: importPlugin,
-      "@next/next": next,
       prettier,
       react,
       "react-hooks": reactHooks,
@@ -91,9 +90,6 @@ export default [
       ...react.configs.recommended.rules,
       ...reactHooks.configs.recommended.rules,
       ...importPlugin.configs.recommended.rules,
-
-      // Next.js Core Web Vitals
-      ...next.configs["core-web-vitals"].rules,
 
       // Prettier formatting rules
       "prettier/prettier": [


### PR DESCRIPTION
## Summary
- register the `@next/next` plugin in ESLint flat config
- include Next.js Core Web Vitals rules globally

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684a018e4484832e93d225a484c7f272